### PR TITLE
Add early stopping feature

### DIFF
--- a/config_breast_cancer.yaml
+++ b/config_breast_cancer.yaml
@@ -12,6 +12,7 @@ train:
   learning_rate: 0.01
   backend: qasm_simulator
   shots: 8000
+  patience: 3
   should_normalise: True
   should_save_each_epoch: False
   on_ibmq: False

--- a/config_breast_cancer.yaml
+++ b/config_breast_cancer.yaml
@@ -13,6 +13,7 @@ train:
   backend: qasm_simulator
   shots: 8000
   patience: 3
+  objective_value: 90
   should_normalise: True
   should_save_each_epoch: False
   on_ibmq: False

--- a/config_iris.yaml
+++ b/config_iris.yaml
@@ -13,7 +13,7 @@ train:
   backend: qasm_simulator
   shots: 8000
   patience: 3
-  objective_value: 20
+  objective_value: 100
   should_normalise: True
   should_save_each_epoch: False
   on_ibmq: False

--- a/config_iris.yaml
+++ b/config_iris.yaml
@@ -13,6 +13,7 @@ train:
   backend: qasm_simulator
   shots: 8000
   patience: 3
+  objective_value: 20
   should_normalise: True
   should_save_each_epoch: False
   on_ibmq: False

--- a/config_iris.yaml
+++ b/config_iris.yaml
@@ -12,6 +12,7 @@ train:
   learning_rate: 0.01
   backend: qasm_simulator
   shots: 8000
+  patience: 3
   should_normalise: True
   should_save_each_epoch: False
   on_ibmq: False

--- a/config_wine.yaml
+++ b/config_wine.yaml
@@ -13,6 +13,7 @@ train:
   backend: qasm_simulator
   shots: 8000
   patience: 3
+  objective_value: 100
   should_normalise: True
   should_save_each_epoch: False
   on_ibmq: False

--- a/config_wine.yaml
+++ b/config_wine.yaml
@@ -12,6 +12,7 @@ train:
   learning_rate: 0.01
   backend: qasm_simulator
   shots: 8000
+  patience: 3
   should_normalise: True
   should_save_each_epoch: False
   on_ibmq: False

--- a/src/iris_model_on_ibmq.py
+++ b/src/iris_model_on_ibmq.py
@@ -85,7 +85,8 @@ def set_epochs(quclassi_object: QuClassi, objective_epochs: int) -> Dict[str, in
 
 
 def train_and_evaluate_iris_on_ibmq(random_state: int, shuffle: bool, train_size: float, should_scale: bool,
-                                    structure: str, epochs: int, learning_rate: float, backend: str, shots: int, patience: Optional[int],
+                                    structure: str, epochs: int, learning_rate: float, backend: str, shots: int,
+                                    patience: Optional[int], objective_value: Optional[float],
                                     should_normalise: bool, should_save_each_epoch: bool) -> Tuple[QuClassi, float, Tuple[time.time, time.time]]:
     """Train and evaluate QuClassi with the iris dataset on IBMQ
 
@@ -99,6 +100,7 @@ def train_and_evaluate_iris_on_ibmq(random_state: int, shuffle: bool, train_size
     :param str backend: backend
     :param int shots: number of executions
     :param Optional[int] patience: patience for early stopping
+    :param Optional[float] objective_value: objective validation value
     :param bool should_normalise: whether or not normalise each data
     :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
     :return QuClassi quclassi: Trained QuClassi
@@ -136,7 +138,8 @@ def train_and_evaluate_iris_on_ibmq(random_state: int, shuffle: bool, train_size
 
         quclassi.train(x_train, y_train,
                        epochs=epochs_dict, learning_rate=learning_rate,
-                       backend=backend, shots=shots, patience=patience, should_normalise=should_normalise,
+                       backend=backend, shots=shots, patience=patience,
+                       objective_value=objective_value, should_normalise=should_normalise,
                        should_save_each_epoch=should_save_each_epoch, on_ibmq=True)
     train_time = time.time() - start_time
     print("Training is done.")

--- a/src/iris_model_on_ibmq.py
+++ b/src/iris_model_on_ibmq.py
@@ -85,7 +85,7 @@ def set_epochs(quclassi_object: QuClassi, objective_epochs: int) -> Dict[str, in
 
 
 def train_and_evaluate_iris_on_ibmq(random_state: int, shuffle: bool, train_size: float, should_scale: bool,
-                                    structure: str, epochs: int, learning_rate: float, backend: str, shots: int, patience: int,
+                                    structure: str, epochs: int, learning_rate: float, backend: str, shots: int, patience: Optional[int],
                                     should_normalise: bool, should_save_each_epoch: bool) -> Tuple[QuClassi, float, Tuple[time.time, time.time]]:
     """Train and evaluate QuClassi with the iris dataset on IBMQ
 
@@ -98,7 +98,7 @@ def train_and_evaluate_iris_on_ibmq(random_state: int, shuffle: bool, train_size
     :param float learning_rate: learning rate
     :param str backend: backend
     :param int shots: number of executions
-    :param int patience: patience for early stopping
+    :param Optional[int] patience: patience for early stopping
     :param bool should_normalise: whether or not normalise each data
     :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
     :return QuClassi quclassi: Trained QuClassi

--- a/src/iris_model_on_ibmq.py
+++ b/src/iris_model_on_ibmq.py
@@ -1,6 +1,6 @@
 import argparse
 import time
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 import mlflow
 import numpy as np

--- a/src/iris_model_on_ibmq.py
+++ b/src/iris_model_on_ibmq.py
@@ -85,7 +85,7 @@ def set_epochs(quclassi_object: QuClassi, objective_epochs: int) -> Dict[str, in
 
 
 def train_and_evaluate_iris_on_ibmq(random_state: int, shuffle: bool, train_size: float, should_scale: bool,
-                                    structure: str, epochs: int, learning_rate: float, backend: str, shots: int,
+                                    structure: str, epochs: int, learning_rate: float, backend: str, shots: int, patience: int,
                                     should_normalise: bool, should_save_each_epoch: bool) -> Tuple[QuClassi, float, Tuple[time.time, time.time]]:
     """Train and evaluate QuClassi with the iris dataset on IBMQ
 
@@ -98,6 +98,7 @@ def train_and_evaluate_iris_on_ibmq(random_state: int, shuffle: bool, train_size
     :param float learning_rate: learning rate
     :param str backend: backend
     :param int shots: number of executions
+    :param int patience: patience for early stopping
     :param bool should_normalise: whether or not normalise each data
     :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
     :return QuClassi quclassi: Trained QuClassi
@@ -135,7 +136,7 @@ def train_and_evaluate_iris_on_ibmq(random_state: int, shuffle: bool, train_size
 
         quclassi.train(x_train, y_train,
                        epochs=epochs_dict, learning_rate=learning_rate,
-                       backend=backend, shots=shots, should_normalise=should_normalise,
+                       backend=backend, shots=shots, patience=patience, should_normalise=should_normalise,
                        should_save_each_epoch=should_save_each_epoch, on_ibmq=True)
     train_time = time.time() - start_time
     print("Training is done.")

--- a/src/quclassi.py
+++ b/src/quclassi.py
@@ -1,7 +1,7 @@
 import copy
 import json
 import os
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import mlflow
 import numpy as np

--- a/src/quclassi.py
+++ b/src/quclassi.py
@@ -131,7 +131,8 @@ class QuClassi():
     def train_and_eval(self, train_data: List[List[float]], train_labels: List[str],
                        dev_data: List[List[float]], dev_label: List[str],
                        epochs: int, learning_rate: float, backend: str,
-                       shots: int, should_normalise: bool, should_save_each_epoch: bool, on_ibmq: bool) -> None:
+                       shots: int, patience: int, should_normalise: bool,
+                       should_save_each_epoch: bool, on_ibmq: bool) -> None:
         """Train and evaluate all quantum circuits
 
         :param List[List[float]] train_data: learning data
@@ -140,6 +141,7 @@ class QuClassi():
         :param float learning_rate: learning rate
         :param str backend: backend
         :param int shots: number of executions
+        :param int patience: patience for early stopping
         :param bool should_normalise: whether or not normalise each data
         :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
         :param bool on_ibmq: whether or not ibmq is used
@@ -150,9 +152,12 @@ class QuClassi():
             msg = f"len(train_data) must be same as len(train_labels), but {len(train_data)} != {len(train_labels)}"
             raise ValueError(msg)
 
+        current_patience = 0
         tqdm_epochs = tqdm(range(1, epochs+1))
         for epoch in tqdm_epochs:
-            tqdm_epochs.set_postfix({"Loss_train": self.latest_loss, "Accuracy_val": self.latest_accuracy})
+            tqdm_epochs.set_postfix({"Loss_train": self.latest_loss,
+                                     "Accuracy_val": self.latest_accuracy,
+                                     "Current_patience": current_patience})
 
             # Train each quantum circuits
             for label in self.unique_labels:
@@ -167,20 +172,28 @@ class QuClassi():
             _, probabilities_list = self.classify(data=train_data, backend=backend, shots=shots,
                                                   should_normalise=should_normalise, on_ibmq=on_ibmq)
 
-            # Calculate the crossentropy between predicions and truths
+            # Calculate and register the crossentropy between predicions and truths
             current_loss = self.calculate_cross_entropy_error(probabilities_list=probabilities_list, true_labels=train_labels)
-
             mlflow.log_metric(f"train_crros_entropy_loss", current_loss, step=epoch)
-
             self.loss_history.append(current_loss)
 
+            # Calculate and register the accuracy
             current_accuracy = self.evaluate(data=dev_data, true_labels=dev_label,
                                              backend=backend, shots=shots,
                                              should_normalise=should_normalise, on_ibmq=on_ibmq)
-
             mlflow.log_metric(f"dev_accuracy", current_accuracy, step=epoch)
-
             self.accuracy_history.append(current_accuracy)
+
+            # Check if early stopping should work
+            if patience > 0:
+                if self.best_accuracy != self.latest_accuracy:
+                    current_patience += 1
+                else:
+                    current_patience = 0
+
+                if current_patience == patience:
+                    print("Early stopping works.")
+                    break
 
     def calculate_cross_entropy_error(self, probabilities_list: List[List[float]], true_labels: List[str]) -> float:
         """Calculate the cross entropy from true labels

--- a/src/quclassi.py
+++ b/src/quclassi.py
@@ -131,7 +131,7 @@ class QuClassi():
     def train_and_eval(self, train_data: List[List[float]], train_labels: List[str],
                        dev_data: List[List[float]], dev_label: List[str],
                        epochs: int, learning_rate: float, backend: str,
-                       shots: int, patience: int, should_normalise: bool,
+                       shots: int, patience: Optional[int], should_normalise: bool,
                        should_save_each_epoch: bool, on_ibmq: bool) -> None:
         """Train and evaluate all quantum circuits
 
@@ -141,7 +141,7 @@ class QuClassi():
         :param float learning_rate: learning rate
         :param str backend: backend
         :param int shots: number of executions
-        :param int patience: patience for early stopping
+        :param Optional[int] patience: patience for early stopping
         :param bool should_normalise: whether or not normalise each data
         :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
         :param bool on_ibmq: whether or not ibmq is used
@@ -187,7 +187,7 @@ class QuClassi():
             self.accuracy_history.append(current_accuracy)
 
             # Check if early stopping should work
-            if patience > 0:
+            if patience is not None and patience > 0:
                 if previous_best_accuracy is not None and previous_best_accuracy >= self.latest_accuracy:
                     current_patience += 1
                 else:

--- a/src/quclassi.py
+++ b/src/quclassi.py
@@ -155,10 +155,6 @@ class QuClassi():
         current_patience = 0
         tqdm_epochs = tqdm(range(1, epochs+1))
         for epoch in tqdm_epochs:
-            tqdm_epochs.set_postfix({"Loss_train": self.latest_loss,
-                                     "Accuracy_val": self.latest_accuracy,
-                                     "Current_patience": current_patience})
-
             # Train each quantum circuits
             for label in self.unique_labels:
                 focused_indices = np.where(np.array(train_labels) == label)[0]
@@ -188,6 +184,10 @@ class QuClassi():
 
             # Check if early stopping should work
             if patience is not None and patience > 0:
+                tqdm_epochs.set_postfix({"Loss_train": self.latest_loss,
+                                         "Accuracy_val": self.latest_accuracy,
+                                         "Current_patience": current_patience})
+
                 if previous_best_accuracy is not None and previous_best_accuracy >= self.latest_accuracy:
                     current_patience += 1
                 else:
@@ -196,6 +196,9 @@ class QuClassi():
                 if current_patience == patience:
                     print("\nEarly stopping works.")
                     break
+            else:
+                tqdm_epochs.set_postfix({"Loss_train": self.latest_loss,
+                                         "Accuracy_val": self.latest_accuracy})
 
     def calculate_cross_entropy_error(self, probabilities_list: List[List[float]], true_labels: List[str]) -> float:
         """Calculate the cross entropy from true labels

--- a/src/quclassi.py
+++ b/src/quclassi.py
@@ -185,7 +185,7 @@ class QuClassi():
 
             # Check if early stopping should work
             if objective_value is not None and objective_value <= current_accuracy:
-                print("\nEarly stopping works.")
+                print(f"\nEarly stopping works since the accuracy {current_accuracy} was reached to {objective_value}.")
                 break
 
             # Check if early stopping should work
@@ -200,7 +200,7 @@ class QuClassi():
                     current_patience = 0
 
                 if current_patience == patience:
-                    print("\nEarly stopping works.")
+                    print(f"\nEarly stopping works since the accuracy seems that it is not going up.")
                     break
             else:
                 tqdm_epochs.set_postfix({"Loss_train": self.latest_loss,

--- a/src/quclassi.py
+++ b/src/quclassi.py
@@ -177,6 +177,8 @@ class QuClassi():
             mlflow.log_metric(f"train_crros_entropy_loss", current_loss, step=epoch)
             self.loss_history.append(current_loss)
 
+            previous_best_accuracy = self.best_accuracy
+
             # Calculate and register the accuracy
             current_accuracy = self.evaluate(data=dev_data, true_labels=dev_label,
                                              backend=backend, shots=shots,
@@ -186,13 +188,13 @@ class QuClassi():
 
             # Check if early stopping should work
             if patience > 0:
-                if self.best_accuracy != self.latest_accuracy:
+                if previous_best_accuracy is not None and previous_best_accuracy >= self.latest_accuracy:
                     current_patience += 1
                 else:
                     current_patience = 0
 
                 if current_patience == patience:
-                    print("Early stopping works.")
+                    print("\nEarly stopping works.")
                     break
 
     def calculate_cross_entropy_error(self, probabilities_list: List[List[float]], true_labels: List[str]) -> float:

--- a/src/quclassi.py
+++ b/src/quclassi.py
@@ -131,8 +131,8 @@ class QuClassi():
     def train_and_eval(self, train_data: List[List[float]], train_labels: List[str],
                        dev_data: List[List[float]], dev_label: List[str],
                        epochs: int, learning_rate: float, backend: str,
-                       shots: int, patience: Optional[int], should_normalise: bool,
-                       should_save_each_epoch: bool, on_ibmq: bool) -> None:
+                       shots: int, patience: Optional[int], objective_value: Optional[float],
+                       should_normalise: bool, should_save_each_epoch: bool, on_ibmq: bool) -> None:
         """Train and evaluate all quantum circuits
 
         :param List[List[float]] train_data: learning data
@@ -142,6 +142,7 @@ class QuClassi():
         :param str backend: backend
         :param int shots: number of executions
         :param Optional[int] patience: patience for early stopping
+        :param Optional[float] objective_value: objective validation value
         :param bool should_normalise: whether or not normalise each data
         :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
         :param bool on_ibmq: whether or not ibmq is used
@@ -181,6 +182,11 @@ class QuClassi():
                                              should_normalise=should_normalise, on_ibmq=on_ibmq)
             mlflow.log_metric(f"dev_accuracy", current_accuracy, step=epoch)
             self.accuracy_history.append(current_accuracy)
+
+            # Check if early stopping should work
+            if objective_value is not None and objective_value <= current_accuracy:
+                print("\nEarly stopping works.")
+                break
 
             # Check if early stopping should work
             if patience is not None and patience > 0:

--- a/src/quclassi_circuit.py
+++ b/src/quclassi_circuit.py
@@ -340,7 +340,10 @@ class QuClassiCircuit():
         """
         fidelity_like = self.get_fidelity_like_value(num_of_zeros=num_of_zeros, shots=shots)  # (1 + |<x|y>|^2)/2
         squared_fidelity = fidelity_like * 2 - 1  # |<x|y>|^2
-        fidelity = np.sqrt(squared_fidelity)  # |<x|y>|
+        if squared_fidelity > 0:
+            fidelity = np.sqrt(squared_fidelity)  # |<x|y>|
+        else:
+            fidelity = 0
 
         if fidelity < 0:
             msg = f"The quantum state fidelity must be non-negative," \
@@ -350,6 +353,7 @@ class QuClassiCircuit():
         if np.isinf(fidelity) or np.isnan(fidelity):
             msg = f"The quantum state fidelity is {fidelity}"
             print(f"fidelity_like: {fidelity_like}")
+            print(f"squared_fidelity: {squared_fidelity}")
             print(f"fidelity: {fidelity}")
 
             raise ValueError(msg)

--- a/src/quclassi_circuit.py
+++ b/src/quclassi_circuit.py
@@ -329,11 +329,12 @@ class QuClassiCircuit():
         """
         return num_of_zeros / shots
 
-    def get_quantum_state_fidelity(self, num_of_zeros: int, shots: int) -> float:
+    def get_quantum_state_fidelity(self, num_of_zeros: int, shots: int, epsilon: float=1e-8) -> float:
         """Get the quantum state fidelity.
 
         :param int num_of_zeros: the number of zeros
         :param int shots: the number of executions
+        :param float epsilon: the number of executions, Defaults to 1e-8
         :raises ValueError: if the fidelity value is negative
         :raises ValueError: if the fidelity value is inf or NaN
         :return float: the quantum state fidelity
@@ -343,7 +344,7 @@ class QuClassiCircuit():
         if squared_fidelity > 0:
             fidelity = np.sqrt(squared_fidelity)  # |<x|y>|
         else:
-            fidelity = 0
+            fidelity = epsilon
 
         if fidelity < 0:
             msg = f"The quantum state fidelity must be non-negative," \

--- a/src/run_model.py
+++ b/src/run_model.py
@@ -36,7 +36,8 @@ def preprocess_dataset(data: List[List[float]], labels: List[str], random_state:
 
 def train_and_evaluate(data: List[List[float]], labels: List[str], prefix: str,
                        random_state: int, shuffle: bool, train_size: float, should_scale: bool,
-                       structure: str, epochs: int, learning_rate: float, backend: str, shots: int, patience: Optional[int],
+                       structure: str, epochs: int, learning_rate: float, backend: str, shots: int,
+                       patience: Optional[int], objective_value: Optional[float],
                        should_normalise: bool, should_save_each_epoch: bool,
                        on_ibmq: bool) -> object:
     """Train and evaluate QuClassi.
@@ -54,6 +55,7 @@ def train_and_evaluate(data: List[List[float]], labels: List[str], prefix: str,
     :param str backend: backend
     :param int shots: number of executions
     :param Optional[int] patience: patience for early stopping
+    :param Optional[float] objective_value: objective validation value
     :param bool should_normalise: whether or not normalise each data
     :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
     :param bool on_ibmq: whether or not ibmq is used
@@ -73,7 +75,8 @@ def train_and_evaluate(data: List[List[float]], labels: List[str], prefix: str,
     # Train and evaluate QuClassi
     quclassi.train_and_eval(x_train, y_train, x_test, y_test,
                             epochs=epochs, learning_rate=learning_rate,
-                            backend=backend, shots=shots, patience=patience, should_normalise=should_normalise,
+                            backend=backend, shots=shots, patience=patience,
+                            objective_value=objective_value, should_normalise=should_normalise,
                             should_save_each_epoch=should_save_each_epoch, on_ibmq=on_ibmq)
 
     # Save the QuClassi model

--- a/src/run_model.py
+++ b/src/run_model.py
@@ -36,7 +36,7 @@ def preprocess_dataset(data: List[List[float]], labels: List[str], random_state:
 
 def train_and_evaluate(data: List[List[float]], labels: List[str], prefix: str,
                        random_state: int, shuffle: bool, train_size: float, should_scale: bool,
-                       structure: str, epochs: int, learning_rate: float, backend: str, shots: int,
+                       structure: str, epochs: int, learning_rate: float, backend: str, shots: int, patience: int,
                        should_normalise: bool, should_save_each_epoch: bool,
                        on_ibmq: bool) -> object:
     """Train and evaluate QuClassi.
@@ -53,6 +53,7 @@ def train_and_evaluate(data: List[List[float]], labels: List[str], prefix: str,
     :param float learning_rate: learning rate
     :param str backend: backend
     :param int shots: number of executions
+    :param int patience: patience for early stopping
     :param bool should_normalise: whether or not normalise each data
     :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
     :param bool on_ibmq: whether or not ibmq is used
@@ -72,7 +73,7 @@ def train_and_evaluate(data: List[List[float]], labels: List[str], prefix: str,
     # Train and evaluate QuClassi
     quclassi.train_and_eval(x_train, y_train, x_test, y_test,
                             epochs=epochs, learning_rate=learning_rate,
-                            backend=backend, shots=shots, should_normalise=should_normalise,
+                            backend=backend, shots=shots, patience=patience, should_normalise=should_normalise,
                             should_save_each_epoch=should_save_each_epoch, on_ibmq=on_ibmq)
 
     # Save the QuClassi model

--- a/src/run_model.py
+++ b/src/run_model.py
@@ -36,7 +36,7 @@ def preprocess_dataset(data: List[List[float]], labels: List[str], random_state:
 
 def train_and_evaluate(data: List[List[float]], labels: List[str], prefix: str,
                        random_state: int, shuffle: bool, train_size: float, should_scale: bool,
-                       structure: str, epochs: int, learning_rate: float, backend: str, shots: int, patience: int,
+                       structure: str, epochs: int, learning_rate: float, backend: str, shots: int, patience: Optional[int],
                        should_normalise: bool, should_save_each_epoch: bool,
                        on_ibmq: bool) -> object:
     """Train and evaluate QuClassi.
@@ -53,7 +53,7 @@ def train_and_evaluate(data: List[List[float]], labels: List[str], prefix: str,
     :param float learning_rate: learning rate
     :param str backend: backend
     :param int shots: number of executions
-    :param int patience: patience for early stopping
+    :param Optional[int] patience: patience for early stopping
     :param bool should_normalise: whether or not normalise each data
     :param bool should_save_each_epoch: whether or not print the information of the quantum curcuit per one epoch
     :param bool on_ibmq: whether or not ibmq is used

--- a/src/run_model.py
+++ b/src/run_model.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import mlflow
 import numpy as np


### PR DESCRIPTION
# What is new
The following feature will be added.
- early stopping using `patience`
	- `patience` is specified in `config.yaml`.
	- Training will stop if the validation value, which is the accuracy for now, does not go up `patience` times.
- early stopping using `objective_value`
	- `objective_value` is also specified in `config.yaml`.
	- Training will stop if the validation value, which is the accuracy for now, reaches to `objective_value`.

Furthermore, the following bug will be fixed, which is not really related to this issue.
- Raising an error when the quantum state fidelity is 0 and then `np.log` runs 
	- If the quantum state fidelity is negative, which is not really should be, `epsilon` is substituted into the quantum state fidelity.